### PR TITLE
Fix admin route gating and add regression test

### DIFF
--- a/src/routes/index.test.tsx
+++ b/src/routes/index.test.tsx
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Outlet } from 'react-router-dom';
+import { AppRoutes } from './index';
+import { useAuth } from '@/context/auth-context';
+
+type MockAuthValue = {
+  user: {
+    id: string;
+    name: string;
+    email: string;
+    role: 'admin' | 'manager' | 'assessor';
+    is_platform_admin?: boolean;
+  } | null;
+  loading: boolean;
+  isFirstLogin: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  register: (name: string, email: string, password: string, organizationName: string) => Promise<void>;
+  refreshUser: () => Promise<void>;
+  clearFirstLogin: () => void;
+};
+
+vi.mock('@/context/auth-context', async () => {
+  const actual = await vi.importActual<typeof import('@/context/auth-context')>('@/context/auth-context');
+  return {
+    ...actual,
+    useAuth: vi.fn(),
+  };
+});
+
+vi.mock('@/layouts/dashboard-layout', () => ({
+  DashboardLayout: () => (
+    <div data-testid="mock-dashboard-layout">
+      <Outlet />
+    </div>
+  ),
+}));
+
+vi.mock('@/pages/admin/dashboard', () => ({
+  AdminDashboard: () => <div>Admin Dashboard</div>,
+}));
+
+const mockUseAuth = vi.mocked(useAuth);
+
+const createAuthValue = (overrides: Partial<MockAuthValue> = {}): MockAuthValue => ({
+  user: {
+    id: 'user-1',
+    name: 'Test User',
+    email: 'test@example.com',
+    role: 'manager',
+    is_platform_admin: false,
+  },
+  loading: false,
+  isFirstLogin: false,
+  login: vi.fn(async (_email: string, _password: string) => {}),
+  logout: vi.fn(() => {}),
+  register: vi.fn(async (_name: string, _email: string, _password: string, _organizationName: string) => {}),
+  refreshUser: vi.fn(async () => {}),
+  clearFirstLogin: vi.fn(() => {}),
+  ...overrides,
+});
+
+describe('AppRoutes admin protection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue(createAuthValue());
+  });
+
+  it('renders forbidden page for non-admin users accessing admin dashboard', async () => {
+    render(
+      <MemoryRouter initialEntries={['/admin/dashboard']}>
+        <AppRoutes />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByText('Access Denied')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "You don't have permission to access this page. Please contact your administrator if you believe this is a mistake."
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,4 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
+import type { ReactNode } from 'react';
 import { useAuth } from '@/context/auth-context';
 
 // Layouts
@@ -56,14 +57,14 @@ export const AppRoutes = () => {
     return <LoadingScreen message="Initializing application..." />;
   }
 
-  // Protected route wrapper
-  const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
+  // Basic authentication wrapper
+  const RequireAuth = ({ children }: { children: ReactNode }) => {
     if (!user) return <Navigate to="/login" replace />;
     return <>{children}</>;
   };
 
   // Auth route wrapper (redirects to dashboard if already logged in)
-  const AuthRoute = ({ children }: { children: React.ReactNode }) => {
+  const AuthRoute = ({ children }: { children: ReactNode }) => {
     if (user) return <Navigate to="/dashboard" replace />;
     return <>{children}</>;
   };
@@ -100,12 +101,12 @@ export const AppRoutes = () => {
       </Route>
 
       {/* Dashboard Routes */}
-      <Route 
-        path="/" 
+      <Route
+        path="/"
         element={
-          <ProtectedRoute>
+          <RequireAuth>
             <DashboardLayout />
-          </ProtectedRoute>
+          </RequireAuth>
         }
       >
         <Route path="dashboard" element={<DashboardPage />} />


### PR DESCRIPTION
## Summary
- rename the local auth guard in `AppRoutes` so the shared `ProtectedRoute` component handles admin and platform admin restrictions
- add a regression test that verifies non-admin users see the forbidden page when navigating to `/admin/dashboard`

## Testing
- npx vitest run src/routes/index.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68dae3c89260832e94a23628aa8bd0ba